### PR TITLE
Fix for broken about links.

### DIFF
--- a/Contact/index.html
+++ b/Contact/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/Extended-API/index.html
+++ b/Extended-API/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Extended-DataViz/index.html
+++ b/Extended-DataViz/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Extended-GUI/index.html
+++ b/Extended-GUI/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/Extended-Networks/index.html
+++ b/Extended-Networks/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Extended-Scraping/index.html
+++ b/Extended-Scraping/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/How-to-work-through-these-tutorials/index.html
+++ b/How-to-work-through-these-tutorials/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Intro-API/index.html
+++ b/Intro-API/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Intro-DataViz/index.html
+++ b/Intro-DataViz/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Intro-GUI/index.html
+++ b/Intro-GUI/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/Intro-Networks/index.html
+++ b/Intro-Networks/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Intro-Scrape/index.html
+++ b/Intro-Scrape/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Landing-Page/index.html
+++ b/Landing-Page/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/Part-0-GUI-Setup/index.html
+++ b/Part-0-GUI-Setup/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/Part-0-Setup-for-APIs/index.html
+++ b/Part-0-Setup-for-APIs/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-0-Setup-for-DataViz/index.html
+++ b/Part-0-Setup-for-DataViz/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-0-Setup-for-IRC-Bot/index.html
+++ b/Part-0-Setup-for-IRC-Bot/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-0-Setup/index.html
+++ b/Part-0-Setup/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-1-Parse/index.html
+++ b/Part-1-Parse/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-1-Quote-Selector/index.html
+++ b/Part-1-Quote-Selector/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-1-Scraper-Setup/index.html
+++ b/Part-1-Scraper-Setup/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-1-Setup-raw-data/index.html
+++ b/Part-1-Setup-raw-data/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-1-Sudoku-Board-Setup/index.html
+++ b/Part-1-Sudoku-Board-Setup/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/Part-2-Giantbomb-API/index.html
+++ b/Part-2-Giantbomb-API/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-2-Graph/index.html
+++ b/Part-2-Graph/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-2-Writing-our-Spider/index.html
+++ b/Part-2-Writing-our-Spider/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-3-JSON-Parsing/index.html
+++ b/Part-3-JSON-Parsing/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-3-Map/index.html
+++ b/Part-3-Map/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-3-Setting-up-SQLAlchemy/index.html
+++ b/Part-3-Setting-up-SQLAlchemy/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-4-Logic-of-the-script/index.html
+++ b/Part-4-Logic-of-the-script/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-4-Pipelining-data/index.html
+++ b/Part-4-Pipelining-data/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Part-5-Running-our-scraper/index.html
+++ b/Part-5-Running-our-scraper/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Save-your-progress/index.html
+++ b/Save-your-progress/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/Setup-your-machine/index.html
+++ b/Setup-your-machine/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/about/index.html
+++ b/about/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/api/extended/index.html
+++ b/api/extended/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/api/index.html
+++ b/api/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/api/intro/index.html
+++ b/api/intro/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/api/part-0/index.html
+++ b/api/part-0/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/api/part-1/index.html
+++ b/api/part-1/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/api/part-2/index.html
+++ b/api/part-2/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/api/part-3/index.html
+++ b/api/part-3/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/api/part-4/index.html
+++ b/api/part-4/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/archives/2013/index.html
+++ b/archives/2013/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/archives/index.html
+++ b/archives/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/begin/how-to-work-through-tutorials/index.html
+++ b/begin/how-to-work-through-tutorials/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/begin/index.html
+++ b/begin/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/begin/save-your-progress/index.html
+++ b/begin/save-your-progress/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/begin/setup-your-machine/index.html
+++ b/begin/setup-your-machine/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/dataviz/extended/index.html
+++ b/dataviz/extended/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/dataviz/index.html
+++ b/dataviz/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/dataviz/intro/index.html
+++ b/dataviz/intro/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/dataviz/part-0/index.html
+++ b/dataviz/part-0/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/dataviz/part-1/index.html
+++ b/dataviz/part-1/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/dataviz/part-2/index.html
+++ b/dataviz/part-2/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/dataviz/part-3/index.html
+++ b/dataviz/part-3/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/excerpt/index.html
+++ b/excerpt/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/gui/index.html
+++ b/gui/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/networks/index.html
+++ b/networks/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/pdf/index.html
+++ b/pdf/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/scrape/extended/index.html
+++ b/scrape/extended/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/scrape/index.html
+++ b/scrape/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/scrape/intro/index.html
+++ b/scrape/intro/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/scrape/part-0/index.html
+++ b/scrape/part-0/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/scrape/part-1/index.html
+++ b/scrape/part-1/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/scrape/part-2/index.html
+++ b/scrape/part-2/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/scrape/part-3/index.html
+++ b/scrape/part-3/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/scrape/part-4/index.html
+++ b/scrape/part-4/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/scrape/part-5/index.html
+++ b/scrape/part-5/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/DataViz/index.html
+++ b/tags/DataViz/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/Extended-API/index.html
+++ b/tags/Extended-API/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Extended-DataViz/index.html
+++ b/tags/Extended-DataViz/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Extended-GUI/index.html
+++ b/tags/Extended-GUI/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Extended-Networks/index.html
+++ b/tags/Extended-Networks/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Extended-Scraping/index.html
+++ b/tags/Extended-Scraping/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/How-to-work-through-these-tutorials/index.html
+++ b/tags/How-to-work-through-these-tutorials/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Intro-Networks/index.html
+++ b/tags/Intro-Networks/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Landing-Page/index.html
+++ b/tags/Landing-Page/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Network/index.html
+++ b/tags/Network/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/Part-0-GUI-Setup/index.html
+++ b/tags/Part-0-GUI-Setup/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-0-Setup-for-APIs/index.html
+++ b/tags/Part-0-Setup-for-APIs/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-0-Setup-for-DataViz/index.html
+++ b/tags/Part-0-Setup-for-DataViz/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-0-Setup-for-IRC-Bot/index.html
+++ b/tags/Part-0-Setup-for-IRC-Bot/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-0-Setup/index.html
+++ b/tags/Part-0-Setup/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-1-Parse/index.html
+++ b/tags/Part-1-Parse/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-1-Quote-Selector/index.html
+++ b/tags/Part-1-Quote-Selector/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-1-Scraper-Setup/index.html
+++ b/tags/Part-1-Scraper-Setup/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-1-Setup-raw-data/index.html
+++ b/tags/Part-1-Setup-raw-data/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-1-Sudoku-Board-Setup/index.html
+++ b/tags/Part-1-Sudoku-Board-Setup/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-2-Giantbomb-API/index.html
+++ b/tags/Part-2-Giantbomb-API/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-2-Graph/index.html
+++ b/tags/Part-2-Graph/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-2-Writing-our-Spider/index.html
+++ b/tags/Part-2-Writing-our-Spider/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-3-JSON-Parsing/index.html
+++ b/tags/Part-3-JSON-Parsing/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-3-Map/index.html
+++ b/tags/Part-3-Map/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-3-Setting-up-SQLAlchemy/index.html
+++ b/tags/Part-3-Setting-up-SQLAlchemy/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-4-Logic-of-the-script/index.html
+++ b/tags/Part-4-Logic-of-the-script/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-4-Pipelining-data/index.html
+++ b/tags/Part-4-Pipelining-data/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Part-5-Running-our-scraper/index.html
+++ b/tags/Part-5-Running-our-scraper/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Save-your-progress/index.html
+++ b/tags/Save-your-progress/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/Setup-your-machine/index.html
+++ b/tags/Setup-your-machine/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/about/index.html
+++ b/tags/about/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/api/index.html
+++ b/tags/api/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/apis/index.html
+++ b/tags/apis/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/archives/2013/index.html
+++ b/tags/archives/2013/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/archives/index.html
+++ b/tags/archives/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/argparse/index.html
+++ b/tags/argparse/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/begin-intro/index.html
+++ b/tags/begin-intro/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/begin/index.html
+++ b/tags/begin/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/coming-soon/index.html
+++ b/tags/coming-soon/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/contact/index.html
+++ b/tags/contact/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/cron/index.html
+++ b/tags/cron/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/data-structures/index.html
+++ b/tags/data-structures/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/docstrings/index.html
+++ b/tags/docstrings/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/file-IO/index.html
+++ b/tags/file-IO/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/generator/index.html
+++ b/tags/generator/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/generators/index.html
+++ b/tags/generators/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/git/index.html
+++ b/tags/git/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/gui/index.html
+++ b/tags/gui/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/import/index.html
+++ b/tags/import/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/index.html
+++ b/tags/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/installation/index.html
+++ b/tags/installation/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/intro-api/index.html
+++ b/tags/intro-api/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/intro-dataviz/index.html
+++ b/tags/intro-dataviz/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/intro-gui/index.html
+++ b/tags/intro-gui/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/intro-network/index.html
+++ b/tags/intro-network/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/intro-scrape/index.html
+++ b/tags/intro-scrape/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/intro-site/index.html
+++ b/tags/intro-site/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/irc/index.html
+++ b/tags/irc/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/iterators/index.html
+++ b/tags/iterators/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/licensing/index.html
+++ b/tags/licensing/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/logging/index.html
+++ b/tags/logging/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/networks/index.html
+++ b/tags/networks/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/packages/index.html
+++ b/tags/packages/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/pdf/index.html
+++ b/tags/pdf/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/postgres/index.html
+++ b/tags/postgres/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/rebase/index.html
+++ b/tags/rebase/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/save/index.html
+++ b/tags/save/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/scrape/index.html
+++ b/tags/scrape/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/scrapy/index.html
+++ b/tags/scrapy/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/setup/index.html
+++ b/tags/setup/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/shell/index.html
+++ b/tags/shell/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/sqlalchemy/index.html
+++ b/tags/sqlalchemy/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/squash/index.html
+++ b/tags/squash/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tags/tags/DataViz/index.html
+++ b/tags/tags/DataViz/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/Network/index.html
+++ b/tags/tags/Network/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/about/index.html
+++ b/tags/tags/about/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/api/index.html
+++ b/tags/tags/api/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/argparse/index.html
+++ b/tags/tags/argparse/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/begin-intro/index.html
+++ b/tags/tags/begin-intro/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/begin/index.html
+++ b/tags/tags/begin/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/contact/index.html
+++ b/tags/tags/contact/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/data-structures/index.html
+++ b/tags/tags/data-structures/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/docstrings/index.html
+++ b/tags/tags/docstrings/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/file-IO/index.html
+++ b/tags/tags/file-IO/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/generator/index.html
+++ b/tags/tags/generator/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/generators/index.html
+++ b/tags/tags/generators/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/git/index.html
+++ b/tags/tags/git/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/gui/index.html
+++ b/tags/tags/gui/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/import/index.html
+++ b/tags/tags/import/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/intro-api/index.html
+++ b/tags/tags/intro-api/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/intro-dataviz/index.html
+++ b/tags/tags/intro-dataviz/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/intro-gui/index.html
+++ b/tags/tags/intro-gui/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/intro-network/index.html
+++ b/tags/tags/intro-network/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/intro-scrape/index.html
+++ b/tags/tags/intro-scrape/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/intro-site/index.html
+++ b/tags/tags/intro-site/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/iterators/index.html
+++ b/tags/tags/iterators/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/licensing/index.html
+++ b/tags/tags/licensing/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/logging/index.html
+++ b/tags/tags/logging/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/packages/index.html
+++ b/tags/tags/packages/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/rebase/index.html
+++ b/tags/tags/rebase/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/save/index.html
+++ b/tags/tags/save/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/scrape/index.html
+++ b/tags/tags/scrape/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/setup/index.html
+++ b/tags/tags/setup/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/shell/index.html
+++ b/tags/tags/shell/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tags/squash/index.html
+++ b/tags/tags/squash/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/tutorials/index.html
+++ b/tags/tutorials/index.html
@@ -41,7 +41,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
             </ul>

--- a/tags/web-scraper/index.html
+++ b/tags/web-scraper/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/tutorials/index.html
+++ b/tutorials/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/~drafts/networks/extended/index.html
+++ b/~drafts/networks/extended/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/~drafts/networks/index.html
+++ b/~drafts/networks/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/~drafts/networks/intro/index.html
+++ b/~drafts/networks/intro/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/~drafts/networks/part-0/index.html
+++ b/~drafts/networks/part-0/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/~drafts/networks/part-1/index.html
+++ b/~drafts/networks/part-1/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/~drafts/networks/part-2/index.html
+++ b/~drafts/networks/part-2/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/~drafts/networks/part-3/index.html
+++ b/~drafts/networks/part-3/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/~drafts/networks/part-4/index.html
+++ b/~drafts/networks/part-4/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/~drafts/networks/part-5/index.html
+++ b/~drafts/networks/part-5/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>

--- a/~drafts/networks/part-6/index.html
+++ b/~drafts/networks/part-6/index.html
@@ -42,7 +42,7 @@
         <div id="nav">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="/about/">About</a></li>
+                <li><a href="/About/">About</a></li>
                 <li><a href="/tutorials/">Tutorials</a></li>
                 <li><a href="/Contact/">Contact</a></li>
                 <li><a href="https://www.wepay.com/donations/1824739360">Donate</a></li>


### PR DESCRIPTION
I'm not quite sure how this works, but I'm going to explain what I did for the sake of simplicity:
1.  Find affected links (in the project directory)
   
   ```
   grep -ir "/about/" ./*
   ```
2.  Replace all occurrences
   
   ```
   perl -e "s|/about/|/About/|g;" -pi $(find ./ -type f)
   ```
3.  There were links pointing to /tag/about, I've left them with lower case
   
   ```
   perl -e "s|tags/About/|tags/about/|g;" -pi $(find ./ -type f)
   ```

I haven't tested it, but I hope this approach works.
